### PR TITLE
v1.0.28: bootstrap CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to `strapi-provider-translate-custom-api` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.28] - 2026-04-26
+
+### Added
+
+- This `CHANGELOG.md`. From this release on, every published version gets an entry summarizing what changed (closes [#30](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/30)).
+
+### Notes
+
+- No runtime changes. This release exists so that `v2.0.0` (the upcoming breaking wire-contract release) has somewhere to be recorded. Versions `1.0.0` through `1.0.27` are not retroactively documented here — see `git log` for that history.
+
+[Unreleased]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v1.0.28...HEAD
+[1.0.28]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v1.0.27...v1.0.28

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-provider-translate-custom-api",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` (Keep a Changelog format) so the upcoming breaking `v2.0.0` release has somewhere to be recorded
- Bumps `package.json` version to `1.0.28`
- No runtime changes

## Why

Per the release plan: `v2.0.0` ships breaking wire-contract changes. Without a CHANGELOG already in the repo, that entry would be the first one — making it hard to communicate "this is a breaking change, here's the migration." This patch release is purely the seed entry.

Versions `1.0.0` through `1.0.27` are not retroactively documented; `git log` is the source of truth for that history.

Closes #30

## Test plan

- [ ] Diff is two files: `CHANGELOG.md` (new) and `package.json` (version bump only)
- [ ] No code changes — `node -e "require('./index.js')"` still loads
- [ ] After merge: `npm publish` (you, manually — `block-npm-publish.sh` hook prevents agentic publishes)

## Note

Depends on #33 (chore: CLAUDE.md tooling) only by branch order — they're functionally independent and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)