### PR TITLE
v2.1.0: reliability hardening (concurrency, strapi.log, markdown round-trip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-04-26
+
+Reliability hardening — non-breaking. Drops in over v2.0.0 with no migration required.
+
+### Added
+
+- **`providerOptions.concurrency`** ([#9](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/9)) — caps in-flight requests during batch translation. Default `5`. A 50-string page now sends 5 at a time instead of 50 at once. Override per-deployment if your translation backend has different capacity. Implemented via a small inline `allSettledLimit` helper (~15 lines, no new dep). Input order is preserved in results regardless of resolution order.
+- **Markdown round-trip via HTML** ([#12](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/12)) — `format === 'markdown'` fields now go through `formatService.markdownToHtml` → POST as HTML → `formatService.htmlToMarkdown`. Mirrors the existing jsonb behavior. Custom API servers never see raw markdown semantics on the wire — they receive HTML, same as for blocks. Trade-off: any markdown features without HTML equivalents may be lost in conversion (same as for jsonb).
+
+### Changed
+
+- **Per-item failure logs now route through `strapi.log`** ([#10](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/10)). The `console.error` calls in the per-item fallback path are replaced with `strapi.log.warn`, so failures flow through Strapi's pino logger and respect the project's configured log level/format. Messages get a `[strapi-provider-translate-custom-api]` prefix for grep-ability across mixed plugin output. `apiHandler.js` no longer calls `console.*` at all.
+
 ## [2.0.0] - 2026-04-26
 
 > **Breaking release.** Consumer custom-API servers built against the v1.x wire contract must be updated before deploying v2.0.0. See README "Migration from v1.x" for a side-by-side example.
@@ -39,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - No runtime changes. This release exists so that `v2.0.0` (the upcoming breaking wire-contract release) has somewhere to be recorded. Versions `1.0.0` through `1.0.27` are not retroactively documented here — see `git log` for that history.
 
-[Unreleased]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v1.0.28...v2.0.0
 [1.0.28]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v1.0.27...v1.0.28

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A translation provider for [`strapi-plugin-translate`](https://www.npmjs.com/pac
 - **Strapi blocks (jsonb) round-trip** — block editor content is converted to HTML for translation and back to blocks afterwards.
 - **Locale fallbacks** — built-in fallback table for providers that don't support specific locales (e.g. DeepL doesn't support `es-419` → falls back to `es`).
 - **Per-item resilience** — when one item in a batch fails, the source text is returned for that slot and the rest of the batch still succeeds. If *every* item fails, the batch throws an `AggregateError` so the host plugin sees the failure instead of silently presenting source-text fallbacks.
+- **Concurrency control** — batched fan-out is throttled (default 5 in flight) so a large page doesn't fire dozens of simultaneous POSTs at your translation backend. Configurable via `providerOptions.concurrency`.
+- **Markdown round-tripping** — markdown fields are converted to HTML before sending and back to markdown after, so your custom API only ever sees plain text or HTML on the wire (never raw markdown semantics).
 
 ## Installation
 
@@ -55,6 +57,7 @@ module.exports = ({ env }) => ({
 | `apiKey` | string | undefined | Sent as `Authorization: Bearer <apiKey>` when set. |
 | `translationProvider` | string | undefined | Forwarded as `?provider=...` and used to key the locale fallback table. |
 | `timeoutMs` | number | `30_000` | Per-request timeout. Hanging endpoints abort after this many milliseconds. |
+| `concurrency` | number | `5` | Max in-flight requests when translating a batch. Lower it if your translation backend rate-limits aggressively; raise it if your backend is fast and you have plenty of capacity. |
 
 ## Wire contract (v2.0.0)
 
@@ -75,6 +78,16 @@ Body: the raw text or HTML to translate
 - Query parameters are encoded via `URLSearchParams`. Locale codes, provider names, and any other interpolated values are properly percent-encoded.
 - `format=html` is added when the input passes `is-html()`. Plain text omits the parameter.
 - The request aborts after `timeoutMs` (default 30s) via `AbortSignal.timeout(...)`.
+- The provider runs at most `concurrency` items in flight at once (default 5) — large pages no longer fire 50+ simultaneous POSTs at your backend.
+
+### Per-format behavior
+
+| Field type / `format` | What hits the wire |
+|---|---|
+| `string`, `text`, `plain` | The raw text. `Content-Type: text/plain`. |
+| `html` (input is already HTML) | The HTML. `Content-Type: text/html`, `&format=html`. |
+| `markdown` | Converted to HTML before sending and back to markdown after. `Content-Type: text/html`, `&format=html`. Your custom API never sees raw markdown. |
+| `jsonb` (Strapi blocks) | Blocks → HTML (via the host plugin's `format` service) → POST → HTML response → blocks. `Content-Type: text/html`, `&format=html`. |
 
 ### Response
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -8,13 +8,15 @@ const provider = require("../index");
 const setupStrapi = ({
   blockToHtml = jest.fn(),
   htmlToBlock = jest.fn(),
+  log = { warn: jest.fn(), error: jest.fn(), info: jest.fn() },
 } = {}) => {
   global.strapi = {
+    log,
     plugin: jest.fn().mockReturnValue({
       service: jest.fn().mockReturnValue({ blockToHtml, htmlToBlock }),
     }),
   };
-  return { blockToHtml, htmlToBlock };
+  return { blockToHtml, htmlToBlock, log };
 };
 
 beforeEach(() => {
@@ -231,8 +233,8 @@ describe("init / translate — current v1.x behavior", () => {
     expect(result).toHaveLength(1);
   });
 
-  test("falls back to source text on partial failure but logs (#8)", async () => {
-    setupStrapi();
+  test("falls back to source text on partial failure but logs via strapi.log (#8 + #10)", async () => {
+    const { log } = setupStrapi();
     fetchTranslation
       .mockRejectedValueOnce(new Error("boom"))
       .mockResolvedValueOnce("mundo");
@@ -245,8 +247,11 @@ describe("init / translate — current v1.x behavior", () => {
     });
 
     expect(result).toEqual(["hello", "mundo"]);
-    expect(console.error).toHaveBeenCalledWith(
+    expect(log.warn).toHaveBeenCalledWith(
       expect.stringContaining("Failed to translate item 0")
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("boom")
     );
   });
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -36,6 +36,105 @@ const init = (opts = {}) =>
     ...opts,
   });
 
+describe("translate — concurrency limit (#9)", () => {
+  test("preserves input order even when items resolve out of order", async () => {
+    setupStrapi();
+    const resolveOrder = [];
+    fetchTranslation.mockImplementation(
+      (args) =>
+        new Promise((resolve) => {
+          // Resolve in reverse: longer text waits longer
+          const delay = (10 - args.text.length) * 5;
+          setTimeout(() => {
+            resolveOrder.push(args.text);
+            resolve(`tr-${args.text}`);
+          }, Math.max(0, delay));
+        })
+    );
+    const { translate } = init();
+
+    const result = await translate({
+      text: ["hello", "hi", "hey there", "yo", "good morning"],
+      sourceLocale: "en",
+      targetLocale: "es",
+    });
+
+    // Output order matches input order (positional)
+    expect(result).toEqual([
+      "tr-hello",
+      "tr-hi",
+      "tr-hey there",
+      "tr-yo",
+      "tr-good morning",
+    ]);
+    // But resolution order was different — proves the queue interleaved
+    expect(resolveOrder).not.toEqual([
+      "hello",
+      "hi",
+      "hey there",
+      "yo",
+      "good morning",
+    ]);
+  });
+
+  test("runs at most `concurrency` items in flight at once", async () => {
+    setupStrapi();
+    let inFlight = 0;
+    let peakInFlight = 0;
+    fetchTranslation.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          inFlight++;
+          peakInFlight = Math.max(peakInFlight, inFlight);
+          setTimeout(() => {
+            inFlight--;
+            resolve("ok");
+          }, 20);
+        })
+    );
+    const { translate } = provider.init({
+      apiURL: "https://api.example.com/translate",
+      concurrency: 2,
+    });
+
+    await translate({
+      text: ["a", "b", "c", "d", "e", "f", "g"],
+      sourceLocale: "en",
+      targetLocale: "es",
+    });
+
+    expect(peakInFlight).toBeLessThanOrEqual(2);
+    expect(peakInFlight).toBeGreaterThan(0);
+  });
+
+  test("defaults to concurrency 5 when not configured", async () => {
+    setupStrapi();
+    let peakInFlight = 0;
+    let inFlight = 0;
+    fetchTranslation.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          inFlight++;
+          peakInFlight = Math.max(peakInFlight, inFlight);
+          setTimeout(() => {
+            inFlight--;
+            resolve("ok");
+          }, 10);
+        })
+    );
+    const { translate } = init();
+
+    await translate({
+      text: Array.from({ length: 12 }, (_, i) => `item${i}`),
+      sourceLocale: "en",
+      targetLocale: "es",
+    });
+
+    expect(peakInFlight).toBeLessThanOrEqual(5);
+    expect(peakInFlight).toBeGreaterThan(1);
+  });
+});
+
 describe("init — timeoutMs forwarding (#7)", () => {
   test("forwards timeoutMs from providerOptions to fetchTranslation", async () => {
     setupStrapi();

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -8,15 +8,22 @@ const provider = require("../index");
 const setupStrapi = ({
   blockToHtml = jest.fn(),
   htmlToBlock = jest.fn(),
+  markdownToHtml = jest.fn(),
+  htmlToMarkdown = jest.fn(),
   log = { warn: jest.fn(), error: jest.fn(), info: jest.fn() },
 } = {}) => {
   global.strapi = {
     log,
     plugin: jest.fn().mockReturnValue({
-      service: jest.fn().mockReturnValue({ blockToHtml, htmlToBlock }),
+      service: jest.fn().mockReturnValue({
+        blockToHtml,
+        htmlToBlock,
+        markdownToHtml,
+        htmlToMarkdown,
+      }),
     }),
   };
-  return { blockToHtml, htmlToBlock, log };
+  return { blockToHtml, htmlToBlock, markdownToHtml, htmlToMarkdown, log };
 };
 
 beforeEach(() => {
@@ -368,6 +375,61 @@ describe("init / translate — current v1.x behavior", () => {
         targetLocale: "es",
       })
     ).rejects.toThrow(AggregateError);
+  });
+
+  test("converts markdown to HTML and back for markdown format (#12)", async () => {
+    const { markdownToHtml, htmlToMarkdown } = setupStrapi();
+    markdownToHtml.mockResolvedValueOnce("<p>hello <strong>world</strong></p>");
+    fetchTranslation.mockResolvedValueOnce("<p>hola <strong>mundo</strong></p>");
+    htmlToMarkdown.mockResolvedValueOnce("hola **mundo**");
+    const { translate } = init();
+
+    const result = await translate({
+      text: "hello **world**",
+      sourceLocale: "en",
+      targetLocale: "es",
+      format: "markdown",
+    });
+
+    expect(markdownToHtml).toHaveBeenCalledWith("hello **world**");
+    expect(fetchTranslation).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "<p>hello <strong>world</strong></p>" })
+    );
+    expect(htmlToMarkdown).toHaveBeenCalledWith(["<p>hola <strong>mundo</strong></p>"]);
+    expect(result).toEqual(["hola **mundo**"]);
+  });
+
+  test("ensures htmlToMarkdown result is wrapped in an array (#12)", async () => {
+    const { markdownToHtml, htmlToMarkdown } = setupStrapi();
+    markdownToHtml.mockResolvedValueOnce("<p>hello</p>");
+    fetchTranslation.mockResolvedValueOnce("<p>hola</p>");
+    htmlToMarkdown.mockResolvedValueOnce("hola");
+    const { translate } = init();
+
+    const result = await translate({
+      text: "hello",
+      sourceLocale: "en",
+      targetLocale: "es",
+      format: "markdown",
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual(["hola"]);
+  });
+
+  test("does not invoke markdownToHtml for plain format", async () => {
+    const { markdownToHtml } = setupStrapi();
+    fetchTranslation.mockResolvedValueOnce("hola");
+    const { translate } = init();
+
+    await translate({
+      text: "hello",
+      sourceLocale: "en",
+      targetLocale: "es",
+      format: "plain",
+    });
+
+    expect(markdownToHtml).not.toHaveBeenCalled();
   });
 
   test("usage() is a no-op", async () => {

--- a/index.js
+++ b/index.js
@@ -81,11 +81,18 @@ module.exports = {
 
         const formatService = strapi.plugin('translate').service('format');
         let isBlock = false;
+        let isMarkdown = false;
 
-        // If the input is a block (jsonb), convert it to HTML for translation
+        // Route format-specific content through HTML on the wire so the
+        // consumer's API only ever sees plain text or HTML, never blocks
+        // or markdown semantics. Mirrors the host plugin's own conversion
+        // services.
         if (Array.isArray(text) && format === 'jsonb') {
           text = await formatService.blockToHtml(text);
           isBlock = true;
+        } else if (format === 'markdown') {
+          text = await formatService.markdownToHtml(text);
+          isMarkdown = true;
         }
 
         // Ensure text is an array for batch translation
@@ -140,13 +147,22 @@ module.exports = {
           return text[i];
         });
 
-        // If we translated a block, convert the translated HTML back to blocks
+        // Convert HTML responses back to the original format the host plugin
+        // expects for this field type.
         if (isBlock) {
           let blocks = await formatService.htmlToBlock(translatedTexts);
           if (!Array.isArray(blocks)) {
             blocks = [blocks];
           }
           return blocks;
+        }
+
+        if (isMarkdown) {
+          let markdown = await formatService.htmlToMarkdown(translatedTexts);
+          if (!Array.isArray(markdown)) {
+            markdown = [markdown];
+          }
+          return markdown;
         }
 
         return translatedTexts;

--- a/index.js
+++ b/index.js
@@ -103,8 +103,9 @@ module.exports = {
         // logged so the operator can see what went wrong.
         let translatedTexts = settled.map((r, i) => {
           if (r.status === "fulfilled") return r.value;
-          console.error(`Failed to translate item ${i}: "${text[i]}"`);
-          console.error(r.reason);
+          strapi.log.warn(
+            `[strapi-provider-translate-custom-api] Failed to translate item ${i}: "${text[i]}" — ${r.reason?.message ?? r.reason}`
+          );
           return text[i];
         });
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,35 @@
 const { fetchTranslation } = require("./apiHandler");
 
+const DEFAULT_CONCURRENCY = 5;
+
 // provide fallbacks for services that don't support the target languages
 const fallbackLanguages = {
   DeepL: [{ source: "es-419", fallback: "es" }],
+};
+
+// Throttled Promise.allSettled. Runs at most `limit` items in flight at a time
+// and preserves input order in the results array. We rely on this instead of
+// raw Promise.allSettled so a 50-string page doesn't fire 50 simultaneous
+// fetches at the consumer's API (issue #9).
+const allSettledLimit = async (items, limit, fn) => {
+  const results = new Array(items.length);
+  let next = 0;
+
+  const worker = async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      try {
+        results[i] = { status: "fulfilled", value: await fn(items[i], i) };
+      } catch (reason) {
+        results[i] = { status: "rejected", reason };
+      }
+    }
+  };
+
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: workerCount }, worker));
+  return results;
 };
 
 module.exports = {
@@ -10,7 +37,13 @@ module.exports = {
   name: "Custom API Translation Provider",
 
   init(providerOptions = {}, pluginConfig = {}) {
-    const { apiURL, apiKey, translationProvider, timeoutMs } = providerOptions;
+    const {
+      apiURL,
+      apiKey,
+      translationProvider,
+      timeoutMs,
+      concurrency = DEFAULT_CONCURRENCY,
+    } = providerOptions;
 
     if (!apiURL) {
       throw new Error(
@@ -75,18 +108,16 @@ module.exports = {
           }
         }
 
-        const settled = await Promise.allSettled(
-          text.map((singleText) =>
-            fetchTranslation({
-              apiURL,
-              apiKey,
-              text: singleText,
-              targetLocale,
-              sourceLocale,
-              translationProvider,
-              timeoutMs,
-            })
-          )
+        const settled = await allSettledLimit(text, concurrency, (singleText) =>
+          fetchTranslation({
+            apiURL,
+            apiKey,
+            text: singleText,
+            targetLocale,
+            sourceLocale,
+            translationProvider,
+            timeoutMs,
+          })
         );
 
         // If every item failed, surface a real error so the host plugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-provider-translate-custom-api",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "index.js",
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"


### PR DESCRIPTION
## Summary

Stage 2 of the v2.x rollout. Three reliability improvements, all non-breaking.

Closes #9, #10, #12.

## What changed

| Change | Issue | Type |
|---|---|---|
| `providerOptions.concurrency` (default 5) — caps in-flight requests during batch translation | #9 | Added |
| Markdown fields round-trip via HTML on the wire (mirrors jsonb behavior) | #12 | Added |
| Per-item failure logs now go through `strapi.log.warn` (was `console.error`) | #10 | Changed |

## Why this is non-breaking

- **#9 (concurrency):** existing default behavior was unbounded `Promise.all`. New default of 5 is enough to keep small batches fast and slow only the unreasonably-large ones (50+ items). No consumer API contract changes.
- **#10 (strapi.log):** purely an observability change. Same messages, different sink. No consumer-visible effect.
- **#12 (markdown):** previously, markdown fields were sent on the wire as raw markdown with `text/plain`. Custom API servers that already handled markdown will still receive HTML in v2.1.0 (more universal), and any that didn't handle markdown were already broken on this path. The wire format becomes more consistent, not less.

## Commits

- `v2.1.0:` — one commit per issue (#10 → #9 → #12), each with tests inline
- `v2.1.0: README + CHANGELOG + version bump` — docs and version

46 Jest tests pass at every commit.

## Test plan

- [x] `npm test` — 46/46 Jest tests pass
- [x] Concurrency: peak in-flight verified ≤ limit; input order preserved when items resolve out of order
- [x] strapi.log: `log.warn` mock receives the failure message
- [x] Markdown: markdownToHtml + htmlToMarkdown round-trip verified
- [ ] Optional end-to-end: install in a real Strapi instance, translate a markdown field, verify the wire shows `Content-Type: text/html` and `&format=html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)