### PR TITLE
v2.2.0: package hygiene (metadata, files whitelist, peer deps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-04-26
+
+Package hygiene — non-breaking. Improves the npm presentation, the install-time signals consumers receive, and the size of the tarball they download.
+
+### Added
+
+- **`peerDependencies` pin** ([#14](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/14)). Declares `strapi-plugin-translate ^1.4.0` so npm warns at install time when consumers pair this provider with an incompatible host plugin version. The host plugin's `format` service surface (which this provider depends on) has been stable since v1.3.0; the `^1.4.0` pin reflects what's actually been tested.
+- **`files` whitelist** in `package.json` ([#13](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/13)). Only the runtime files (`index.js`, `apiHandler.js`), `README.md`, `CHANGELOG.md`, and `LICENSE` ship to npm now. Tarball dropped from 14 files / 16.2 kB to 6 files / 8.4 kB. Tests, internal tooling, project-context files, and the legacy `test.js` scratch script no longer pollute consumer installs.
+- **`engines.node: ">=18"`** in `package.json` — formalizes the Node version assumption (we use `AbortSignal.timeout`, native `fetch`, `URLSearchParams`).
+
+### Changed
+
+- **`package.json` metadata cleanup** ([#13](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/13)). Populated `description`, `keywords`, `author`, `homepage`, `bugs`. Corrected `license` from `ISC` (default scaffold) to `MIT` to match the actual `LICENSE` file. The npm page now reflects what the package actually is.
+
 ## [2.1.0] - 2026-04-26
 
 Reliability hardening — non-breaking. Drops in over v2.0.0 with no migration required.
@@ -52,7 +66,8 @@ Reliability hardening — non-breaking. Drops in over v2.0.0 with no migration r
 
 - No runtime changes. This release exists so that `v2.0.0` (the upcoming breaking wire-contract release) has somewhere to be recorded. Versions `1.0.0` through `1.0.27` are not retroactively documented here — see `git log` for that history.
 
-[Unreleased]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v1.0.28...v2.0.0
 [1.0.28]: https://github.com/ksdhir/strapi-provider-translate-custom-api/compare/v1.0.27...v1.0.28

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ app.post("/translate", async (req, res) => {
 ## Compatibility
 
 - Requires Strapi v4. Strapi v5 is not yet supported because the host plugin (`strapi-plugin-translate`) does not yet ship a v5-compatible release.
-- Tested against `strapi-plugin-translate ^1.4.0`. A formal `peerDependencies` pin will land in a future release.
+- Declared as a `peerDependency` on `strapi-plugin-translate ^1.4.0`. npm will warn if you install this provider against an incompatible host plugin version. (The same surface — `format.blockToHtml`, `format.htmlToBlock`, `format.markdownToHtml`, `format.htmlToMarkdown` — has been stable in the host plugin since v1.3.0; the `^1.4.0` pin matches what the provider has actually been tested against.)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,15 @@
 {
   "name": "strapi-provider-translate-custom-api",
-  "version": "2.1.0",
+  "version": "2.2.0",
+  "description": "Custom HTTP-endpoint translation provider for strapi-plugin-translate. Route translation requests through any URL you control instead of being locked into DeepL/Google/ChatGPT.",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "apiHandler.js",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
@@ -10,16 +18,33 @@
       "**/__tests__/**/*.test.js"
     ]
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": "",
+  "keywords": [
+    "strapi",
+    "strapi-plugin",
+    "strapi-provider",
+    "translate",
+    "translation",
+    "i18n",
+    "custom-api"
+  ],
+  "author": "Karan Singh Dhir <ksinghdhir1@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://github.com/ksdhir/strapi-provider-translate-custom-api#readme",
+  "bugs": {
+    "url": "https://github.com/ksdhir/strapi-provider-translate-custom-api/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ksdhir/strapi-provider-translate-custom-api.git"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "is-html": "^3.1.0"
+  },
+  "peerDependencies": {
+    "strapi-plugin-translate": "^1.4.0"
   },
   "devDependencies": {
     "jest": "^30.3.0"


### PR DESCRIPTION
## Summary

Stage 3 of the v2.x rollout. Three non-breaking package-hygiene changes.

Closes #13, #14.

## What changed

| Change | Issue | Why it matters |
|---|---|---|
| `package.json` metadata: description, keywords, author, license: MIT, engines.node ≥ 18, homepage, bugs | #13 | npm page now reflects what the package actually is; license matches the `LICENSE` file. |
| `files` whitelist | #13 | Tarball drops from 14 files / 16.2 kB to 6 files / 9.0 kB. Tests, `.claude/`, `CLAUDE.md`, `test.js` no longer ship to consumers. |
| `peerDependencies: { "strapi-plugin-translate": "^1.4.0" }` | #14 | npm warns at install time when paired with an incompatible host plugin. |

## What ships now

```
CHANGELOG.md  LICENSE  README.md  apiHandler.js  index.js  package.json
```

## Why this is non-breaking

- Metadata changes don't affect runtime behavior.
- `files` whitelist removes things consumers were never supposed to use.
- `peerDependencies` is *advisory* in modern npm — produces a warning, doesn't fail installs.
- No code changes; 46/46 Jest tests still green.

## Test plan

- [x] `npm test` — 46/46 green
- [x] `npm pack --dry-run` shows only the whitelisted files
- [x] `npm pack --dry-run` shows version 2.2.0
- [x] License field matches the `LICENSE` file (MIT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)