### PR TITLE
docs: Stage 5 — custom API contract, silent-fallback, JSDoc invariants, README fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Memoize the `is-html` dynamic import** ([#25](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/25)). `apiHandler.js` previously did `await import("is-html")` on every `fetchTranslation` call. The import is now hoisted to module load and the resulting promise is cached, so the cost is paid once. Behavior is unchanged; this is a non-breaking micro-optimization.
 - **Drop the unused `priority` field from the `translate()` JSDoc** ([#27](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/27)). The host plugin passes `priority` through but this provider has never consumed it, and there's no defined wire semantic for forwarding it to a user's custom API. Documenting an option the provider doesn't act on was misleading; the field is removed from the JSDoc. No runtime change.
 
+### Documentation
+
+- **Custom API server contract section** ([#19](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/19)). Promoted the existing wire-contract spec into a labelled "Custom API server contract" section in the README with an explicit anchor and a status-code semantics table (2xx, 2xx-empty, non-2xx) covering provider behavior and operator guidance.
+- **Failure behavior section** ([#20](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/20)). Documented the two layers of failure handling: per-item silent fallback to source text via `strapi.log.warn` (since v2.1.0), and batch-level `AggregateError` when every item fails (since v2.0.0). Notes that no `silentFallback` opt-out exists today and would land as a separate `providerOptions` entry in a future minor release.
+- **Host plugin invariants in `translate()` JSDoc** ([#21](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/21)). Added a JSDoc block above `translate()` in `index.js` capturing the five invariants enforced by `strapi-plugin-translate` (text always an array, format homogeneous, length and order preserved, jsonb is nested arrays, priority is a no-op). Mirrored a short version in `CLAUDE.md`.
+- **README minor fixes** ([#22](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/22)). Verified no stale `url` references remain (the field is `apiURL`), added `concurrency` to the example config block so it matches the `providerOptions` table, and confirmed the Strapi v5 compatibility note is still accurate.
+
 ## [2.2.0] - 2026-04-26
 
 Package hygiene — non-breaking. Improves the npm presentation, the install-time signals consumers receive, and the size of the tarball they download.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,16 @@ Response: <raw translated text>   (text/plain, response.text())
 
 Non-2xx responses throw inside `fetchTranslation`, which then catches and returns the original text.
 
+## Host plugin invariants
+
+These are guaranteed by `strapi-plugin-translate`'s service layer (`server/services/translate.js`) and the provider relies on them. Don't break them. Full prose lives in the JSDoc above `translate()` in `index.js`; the short list:
+
+1. `text` is **always an array** when called from the host plugin. The single-string normalization in `translate()` is only for ad-hoc callers.
+2. `format` is **homogeneous within a call** — never mixed.
+3. The returned array **must match input length and order**. Host plugin maps results back by index; `allSettledLimit` preserves order even when items resolve out of sequence.
+4. For `format === 'jsonb'`, each element of `text` is itself an array of blocks (`[[blocksA], [blocksB], ...]`). `formatService.blockToHtml` / `htmlToBlock` handle the nested shape.
+5. `priority` is end-to-end plumbing only — currently a no-op everywhere.
+
 ## Design choices worth knowing
 
 - **Plain-text response, not JSON.** The custom API must respond with the translated string in the body — no JSON envelope.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,32 @@ app.post("/translate", async (req, res) => {
 app.listen(3000);
 ```
 
+## Failure behavior
+
+Translation failures are handled at two distinct layers — per-item and per-batch — and the provider deliberately reports them differently.
+
+### Per-item: silent fallback to source text (since v2.1.0)
+
+When a single item in a batch fails (non-2xx response, network error, timeout, empty response body), the provider:
+
+1. Catches the error inside `allSettledLimit`.
+2. Logs a warning via `strapi.log.warn` with the prefix `[strapi-provider-translate-custom-api]`, the array index of the failed item, the original source text, and the error message.
+3. Substitutes the original source text into that slot of the result array so the rest of the batch still completes.
+
+This means a content editor saving a page where one field couldn't be translated will see source-language text in that field — not an error, not an empty string. The batch returns `2xx` to the host plugin and the editor can manually retranslate the affected field. The `strapi.log.warn` route (added in v2.1.0, [#10](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/10)) flows through Strapi's pino logger, so failures respect your project's configured log level and format and can be surfaced in dashboards alongside the rest of your Strapi logs.
+
+Before v2.1.0 these failures were emitted via `console.error`. Before v2.0.0 they were silently swallowed entirely.
+
+### Batch-level: throws `AggregateError` when every item fails (since v2.0.0)
+
+If **every** item in the batch fails (e.g. your custom API is down, the API key is wrong, the URL is misrouted), the provider throws an `AggregateError` whose `errors` field contains the per-item rejection reasons. The host plugin sees the error and surfaces it to the editor instead of silently presenting an entire page of source-text fallbacks that look like successful translations.
+
+This was introduced in v2.0.0 ([#8](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/8)) to fix the v1.x behavior where catastrophic failures were indistinguishable from successful translations.
+
+### No silent-fallback opt-out today
+
+There is no `silentFallback: false` flag that converts the per-item warning into a thrown error. If you need that behavior — for example, you'd rather have the whole batch fail loudly than ship source-text fallbacks to your editors — open an issue describing the use case. It would land as a new entry in `providerOptions` in a future minor release; this PR documents the *current* behavior only.
+
 ## Migration from v1.x
 
 If you have a custom API server speaking the v1.x contract, you need to update it before installing v2.0.0. The differences:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ module.exports = ({ env }) => ({
         apiKey: env("TRANSLATION_API_KEY"),      // optional; sent as Bearer token
         translationProvider: "MyProvider",       // optional label, see fallback table
         timeoutMs: 30_000,                       // optional, default 30s
+        concurrency: 5,                          // optional, default 5
       },
       translatedFieldTypes: [
         "string",

--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ module.exports = ({ env }) => ({
 | `timeoutMs` | number | `30_000` | Per-request timeout. Hanging endpoints abort after this many milliseconds. |
 | `concurrency` | number | `5` | Max in-flight requests when translating a batch. Lower it if your translation backend rate-limits aggressively; raise it if your backend is fast and you have plenty of capacity. |
 
-## Wire contract (v2.0.0)
+## Custom API server contract
+
+<a id="custom-api-server-contract"></a>
+
+This section is the spec for the HTTP server you put behind `apiURL`. It covers query parameters, the HTTP method, status-code semantics, the response body shape, and a minimal Express implementation. It also doubles as the v2.0.0 wire contract — the rules below are what the provider has spoken on the wire since v2.0.0.
 
 The provider issues one POST per item in the batch.
 
@@ -91,9 +95,15 @@ Body: the raw text or HTML to translate
 
 ### Response
 
-- **2xx**: the response body is read via `response.text()` and used as the translated value. The body must be plain text — no JSON envelope.
-- **Non-2xx**: throws. Per-item failures fall back to source text (with a logged error); a batch where *every* item fails throws an `AggregateError`.
-- **Empty body**: throws as if it were a non-2xx error.
+The response body must be the translated string in the body — **plain text, no JSON envelope**. The provider reads the body via `response.text()` and uses it directly as the translation.
+
+| Status | Meaning | Provider behavior |
+|---|---|---|
+| `2xx` with non-empty body | Success. Body is the translated text. | Used as-is for the slot. |
+| `2xx` with empty body | Treated as failure. | Throws inside `fetchTranslation`; the slot falls back to source text and a warning is logged. If every item fails, the batch throws `AggregateError`. |
+| Any non-2xx (`4xx`, `5xx`) | Failure. The HTTP status is included in the thrown error. | Same as empty body — per-item fallback to source text + warning, or batch-level `AggregateError`. |
+
+Authentication errors should use `401`/`403` and return any human-readable message in the body. Validation failures (unsupported locale, missing field) should use `4xx`. Upstream translation backend errors should use `5xx`. The provider does not distinguish between these on the wire — they all funnel into the same fallback path — but accurate status codes show up in the warning logs and make operator debugging far easier.
 
 ### Example custom API server (Express, v2.0.0)
 

--- a/index.js
+++ b/index.js
@@ -62,13 +62,44 @@ module.exports = {
 
     return {
       /**
+       * Translate a batch of strings (or block arrays) for the host plugin.
+       *
+       * Host plugin invariants
+       * ----------------------
+       * The following invariants are enforced by `strapi-plugin-translate`'s
+       * service layer (see `strapi-plugin-translate/server/services/translate.js`).
+       * They're documented here so contributors don't accidentally break the
+       * provider's contract with the host:
+       *
+       * 1. `text` is **always an array** when called from the host plugin.
+       *    The single-string convenience path (`text` → `[text]`) below
+       *    exists only for ad-hoc consumers; the host always sends an array.
+       * 2. `format` is **homogeneous within a call** — the host never mixes
+       *    `'plain'`, `'markdown'`, `'html'`, and `'jsonb'` items in one
+       *    batch. The format conversion paths (markdown → HTML, blocks →
+       *    HTML) safely apply to the whole array.
+       * 3. The returned array **must match input length and order** — the
+       *    host maps results back to the originating fields by index.
+       *    `allSettledLimit` preserves order even when items resolve out of
+       *    sequence; do not switch to `Promise.race` or any unordered fan-out.
+       * 4. For `format === 'jsonb'`, each array element is itself an array
+       *    of Strapi blocks (`text` is `[[blocksA], [blocksB], ...]`).
+       *    `formatService.blockToHtml` accepts that nested shape and yields
+       *    a flat array of HTML strings; `formatService.htmlToBlock` does
+       *    the inverse on the way back.
+       * 5. `priority` is end-to-end plumbing only — currently a **no-op**
+       *    everywhere (host plugin and this provider). Don't gate logic
+       *    on it without coordinating with the host.
+       *
        * @param {{
-       *  text:string|string[],
+       *  text: string | string[],
        *  sourceLocale: string,
        *  targetLocale: string,
-       *  format?: 'plain'|'markdown'|'html'|'jsonb'
+       *  format?: 'plain' | 'markdown' | 'html' | 'jsonb'
        * }} options all translate options
-       * @returns {string[]|object[]} the input text(s) translated
+       * @returns {Promise<string[] | object[]>} the input text(s) translated.
+       *   Length and order match `options.text`. For `format === 'jsonb'`,
+       *   each element is an array of Strapi blocks.
        */
       async translate(options) {
         let { sourceLocale, targetLocale, format } = options;


### PR DESCRIPTION
## Summary

Stage 5 documentation pass — pure docs, no runtime code changes. Five commits, one per issue plus a CHANGELOG entry.

### Commit-by-commit

- **`docs: document the custom API server contract (#19)`** — Promotes the existing wire-contract spec into a labelled "Custom API server contract" section in the README with an explicit anchor and a status-code semantics table (2xx, 2xx-empty, non-2xx) covering provider behavior plus operator guidance on which codes to use for which failure mode. Closes #19.
- **`docs: document silent-fallback failure behavior (#20)`** — Adds a "Failure behavior" section spelling out the two layers: per-item silent fallback to source text via `strapi.log.warn` (since v2.1.0) and batch-level `AggregateError` when every item fails (since v2.0.0). Notes that no `silentFallback` opt-out exists today and would land as a separate `providerOptions` entry. Closes #20.
- **`docs: pin host-plugin invariants in JSDoc on translate() (#21)`** — JSDoc block above `translate()` in `index.js` capturing all five invariants from the host plugin (text always an array, format homogeneous, length and order preserved, jsonb is nested arrays, priority is a no-op). Mirrored a short version in `CLAUDE.md` pointing back at the JSDoc as the canonical location. Closes #21.
- **`docs: README minor fixes (#22)`** — Verified no stale `url` references remain (`apiURL` is correct), added `concurrency` to the example config block so it matches the `providerOptions` table, confirmed the v5 compatibility note is still accurate. Closes #22.
- **`docs: CHANGELOG [Unreleased] entries`** — Adds a Documentation block under `## [Unreleased]` summarizing the four docs deliveries above. **No `package.json` version bump** — maintainer batches the version bump after merging multiple Stage 5/6 PRs.

## Files touched

- `README.md` — custom API server contract section, status-code table, failure-behavior section, concurrency in example config
- `index.js` — JSDoc only on `translate()`, no logic changes
- `CLAUDE.md` — short host-plugin-invariants section pointing at the JSDoc
- `CHANGELOG.md` — `[Unreleased]` Documentation entries

## Test plan

- [ ] `npm test` is green (46/46) — confirmed locally on each commit
- [ ] No `package.json` version, dependency, or script changes
- [ ] No new files outside the allowed set (`README.md`, `CLAUDE.md`, `CHANGELOG.md`, `index.js`)
- [ ] Each commit carries the `Co-Authored-By` trailer
- [ ] Closing keywords for #19, #20, #21, #22 are present in commit messages and this PR body

Closes #19.
Closes #20.
Closes #21.
Closes #22.