### PR TITLE
fix(ci): sync lockfile, add .npmrc legacy-peer-deps so npm ci works

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Don't auto-install peerDependencies. We declare strapi-plugin-translate as
+# a peer for npm-level compatibility warnings (issue #14), but the test suite
+# mocks all of its surface — installing the entire @strapi/strapi tree just
+# to run unit tests would inflate node_modules and the lockfile by 20k+
+# entries for no benefit.
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,24 @@
 {
   "name": "strapi-provider-translate-custom-api",
-  "version": "1.0.28",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-provider-translate-custom-api",
-      "version": "1.0.28",
-      "license": "ISC",
+      "version": "2.2.0",
+      "license": "MIT",
       "dependencies": {
         "is-html": "^3.1.0"
       },
       "devDependencies": {
         "jest": "^30.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "strapi-plugin-translate": "^1.4.0"
       }
     },
     "node_modules/@babel/code-frame": {


### PR DESCRIPTION
## Why CI is red

The CI workflow we just landed in PR #40 fails on every Node matrix job (18, 20, 22):

\`\`\`
npm error code EUSAGE
npm error npm ci can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: strapi-plugin-translate@1.4.3 from lock file
npm error Missing: @strapi/strapi@4.26.1 from lock file
... (~20 more lines)
\`\`\`

Root cause: \`package-lock.json\` hadn't been regenerated since \`v1.0.28\` (it still had \`version: 1.0.28\` and \`license: ISC\` inside it), and the \`peerDependencies\` entry added in \`v2.2.0\` (#14) was never reflected. \`npm ci\` enforces strict sync.

## The fix

| Change | Why |
|---|---|
| Add \`.npmrc\` with \`legacy-peer-deps=true\` | The Jest suite mocks all of \`strapi-plugin-translate\`'s surface — installing the entire \`@strapi/strapi\` tree just to run unit tests would balloon the lockfile by ~20k lines for no benefit. \`legacy-peer-deps\` tells npm to skip auto-installing peers (npm 6 behavior). |
| Regenerate \`package-lock.json\` | With the new policy, the diff is small: version 1.0.28 → 2.2.0, license ISC → MIT, the \`engines\` block. \~10 lines total. |

Without \`.npmrc\`, regenerating the lockfile would have produced a 23k-line diff (the full \`@strapi/strapi\` transitive tree).

## Tarball impact

None. \`.npmrc\` and \`package-lock.json\` are excluded by the \`files\` whitelist landed in v2.2.0.

## Test plan

- [x] \`npm ci\` succeeds locally (Node 24)
- [x] \`npm test\` — 46/46 green
- [x] \`npx prettier@3 --check .\` — clean
- [ ] CI run on this PR confirms all three Node matrix jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)