### PR TITLE
feat: support strapi-plugin-translate v2 (Strapi 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- **Strapi 5 support via `strapi-plugin-translate` v2.** Broadened the `peerDependencies` range from
+  `strapi-plugin-translate ^1.4.0` to `^1.4.0 || ^2.0.0-next.4`, so the same provider build works on both
+  Strapi 4 (plugin v1.x) and Strapi 5 (plugin v2.x). The provider's only host coupling — the `format`
+  service surface (`blockToHtml` / `htmlToBlock` / `markdownToHtml` / `htmlToMarkdown`) and the provider
+  contract (`init() → { translate, usage }`) — is identical in the plugin's v1.x and v2.x lines (verified
+  against `strapi-plugin-translate@2.0.0-next.4`), so **no runtime code changed**. Broadening the peer
+  range is additive → non-breaking (ships as a **minor**). Note: the plugin's v2 line is a prerelease
+  (`2.0.0-next.x`) — run an end-to-end translate against a real Strapi 5 instance before production.
 - **GitHub Actions CI workflow** ([#29](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/29)). `.github/workflows/ci.yml` runs `npm ci && npm test` on Node 18 / 20 / 22 for every push and pull request against `main`. PRs now show a CI status check before merge.
 - **Prettier check in CI** ([#31](https://github.com/ksdhir/strapi-provider-translate-custom-api/issues/31)). Separate job runs `npx prettier@3 --check .` so a formatting drift breaks the build. Configured via `.prettierrc.json` (`printWidth: 100`, double quotes, semicolons, `trailingComma: "es5"`) and `.prettierignore` (lockfile, `.claude/` tooling, `CHANGELOG.md`). Prettier itself is not added to `devDependencies` — `npx` fetches a pinned version on demand to keep the lockfile small.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ These are guaranteed by `strapi-plugin-translate`'s service layer (`server/servi
 
 ## Compatibility
 
-README states Strapi v4; v5 is untested. The `strapi.plugin('translate').service('format')` call assumes the host plugin's service shape — if `strapi-plugin-translate` changes that API in a future major, `blockToHtml` / `htmlToBlock` need to be re-checked.
+Works with `strapi-plugin-translate` v1.x (Strapi 4) **and** v2.x (Strapi 5) — `peerDependency: "^1.4.0 || ^2.0.0-next.4"`. The `strapi.plugin('translate').service('format')` surface (`blockToHtml` / `htmlToBlock` / `markdownToHtml` / `htmlToMarkdown`) and the provider contract (`init() → { translate, usage }`) are identical across the plugin's v1.x and v2.x lines (verified against `2.0.0-next.4`), so the provider runs unchanged on both. The v2 line is a prerelease today — re-check this surface (and re-run an end-to-end translate) if the host plugin changes it in a future major.
 
 ## Local testing
 

--- a/README.md
+++ b/README.md
@@ -201,8 +201,9 @@ app.post("/translate", async (req, res) => {
 
 ## Compatibility
 
-- Requires Strapi v4. Strapi v5 is not yet supported because the host plugin (`strapi-plugin-translate`) does not yet ship a v5-compatible release.
-- Declared as a `peerDependency` on `strapi-plugin-translate ^1.4.0`. npm will warn if you install this provider against an incompatible host plugin version. (The same surface — `format.blockToHtml`, `format.htmlToBlock`, `format.markdownToHtml`, `format.htmlToMarkdown` — has been stable in the host plugin since v1.3.0; the `^1.4.0` pin matches what the provider has actually been tested against.)
+- **Strapi 4 and Strapi 5.** Works with `strapi-plugin-translate` v1.x (Strapi 4) and its v2.x line (Strapi 5) — the same provider build supports both.
+- Declared as a `peerDependency` on `strapi-plugin-translate ^1.4.0 || ^2.0.0-next.4`. npm will warn if you install this provider against an incompatible host plugin version. The provider depends only on the host's `format` service surface — `format.blockToHtml`, `format.htmlToBlock`, `format.markdownToHtml`, `format.htmlToMarkdown` — plus the provider contract (`init() → { translate, usage }`). Both are identical in the plugin's v1.x and v2.x lines (verified against `strapi-plugin-translate@2.0.0-next.4`), so no code changes were needed for Strapi 5.
+- The plugin's Strapi 5 line (`2.0.0-next.x`) is currently a **prerelease** — pin it and run an end-to-end translate check before relying on it in production.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "strapi-plugin-translate": "^1.4.0"
+        "strapi-plugin-translate": "^1.4.0 || ^2.0.0-next.4"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "is-html": "^3.1.0"
   },
   "peerDependencies": {
-    "strapi-plugin-translate": "^1.4.0"
+    "strapi-plugin-translate": "^1.4.0 || ^2.0.0-next.4"
   },
   "devDependencies": {
     "jest": "^30.3.0"


### PR DESCRIPTION
Broaden peerDependencies to "^1.4.0 || ^2.0.0-next.4" so the same provider build works on both Strapi 4 (plugin v1.x) and Strapi 5 (plugin v2.x).

The provider's only host coupling -- the format service surface (blockToHtml/htmlToBlock/markdownToHtml/htmlToMarkdown) and the provider contract (init() -> { translate, usage }) -- is identical in the plugin's v1.x and v2.x lines (verified against strapi-plugin-translate@2.0.0-next.4), so no runtime code changed. Additive peer range = non-breaking, ships as a minor (2.3.0).

The v2 line is a prerelease (2.0.0-next.x); run an end-to-end translate against a real Strapi 5 instance before production.